### PR TITLE
Add BLE scan and delay

### DIFF
--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -1,4 +1,7 @@
-use btleplug::api::{Central, Characteristic, Manager as _, Peripheral as _, WriteType};
+use std::thread;
+use std::time::Duration;
+
+use btleplug::api::{Central, Characteristic, Manager as _, Peripheral as _, WriteType, ScanFilter};
 use btleplug::platform::{Adapter, Manager, Peripheral};
 
 use uuid::Uuid;
@@ -11,6 +14,10 @@ lazy_static! {
 }
 
 async fn find_device(central: &Adapter) -> Option<Peripheral> {
+    central.start_scan(ScanFilter::default()).await.unwrap();
+
+    thread::sleep(Duration::from_secs(2));
+
     for p in central.peripherals().await.unwrap() {
         if p.properties()
             .await


### PR DESCRIPTION
I found this edit necessary otherwise the device would never be found. Taken from example on `btleplug`:
https://docs.rs/btleplug/0.11.5/btleplug/
